### PR TITLE
Добавлено:проверка того, что конфиг существует

### DIFF
--- a/scripts/filter_config.sh
+++ b/scripts/filter_config.sh
@@ -20,6 +20,8 @@ fi
 if [ -f $SYSCONFIG ]; then
 	# shellcheck disable=SC1090
 	. $SYSCONFIG
+else
+        echo "Не найден конфигурационный файл $SYSCONFIG" && exit 2
 fi
 
 # shellcheck disable=SC1090

--- a/scripts/filter_config.sh
+++ b/scripts/filter_config.sh
@@ -21,7 +21,12 @@ if [ -f $SYSCONFIG ]; then
 	# shellcheck disable=SC1090
 	. $SYSCONFIG
 else
-        echo "Не найден конфигурационный файл $SYSCONFIG" && exit 2
+        echo "Не настроен до конца satellite. Создайте файл $SYSCONFIG и"
+	echo "укажите в нём переменную DNS_IP, указывающую IP адрес страницы-заглушки."
+	echo "Это необходимо для корректной проверки DNS-фильтрации."
+	echo "Все опции $SYSCONFIG:"
+	echo "https://github.com/carbonsoft/reductor_satellite_installer#Специфика-провайдера"
+	exit 2
 fi
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Если его нет, то не запускаем проверки.
Причина: "пропуски" dns и нет отчетов на почту.